### PR TITLE
fix(event): CO-1080 Add disable event save button for form to prevent…

### DIFF
--- a/src/main/resources/public/template/edit-event.html
+++ b/src/main/resources/public/template/edit-event.html
@@ -5,11 +5,14 @@
 
 	<article class="twelve cell">
 		<div name="form" guard-root guard-ignore-template>
+
+			<!-- title form -->
 			<div class="row vertical-spacing">
 				<label class="two cell"><i18n>timelinegenerator.event.headline</i18n></label>
 				<input type="text" i18n-placeholder="timelinegenerator.event.placeholder" class="ten cell" ng-model="event.headline" required input-guard></input>
 			</div>
 
+			<!-- Date form -->
 			<div class="row vertical-spacing">
 				<label class="two cell"><i18n>timelinegenerator.event.date</i18n></label>
 				<div class="ten cell">
@@ -42,6 +45,8 @@
 					</div>
 				</div>
 			</div>
+
+			<!-- Media type form -->
 			<div class="row vertical-spacing">
 				<label class="two cell"><i18n>timelinegenerator.select.media.type</i18n> </label>
 				<div class="ten cell height">
@@ -60,6 +65,7 @@
 				</div>
 			</div>
 
+			<!-- editor text content form -->
 			<div class="twelve cell">
 				<label class="two cell"><i18n>timelinegenerator.event.text</i18n></label>
 				<div class="ten cell">
@@ -70,7 +76,7 @@
 			<div class="twelve cell warning" ng-if="event.error !== undefined" translate content="[[event.error]]">
 			</div>
 
-			<button class="right-magnet" ng-class="" reset-guard="saveEventEdit()" ng-disabled="form.$invalid"><i18n>save</i18n></button>
+			<button class="right-magnet" ng-class="" reset-guard="saveEventEdit()" ng-disabled="form.$invalid || !isEventFormValid()"><i18n>save</i18n></button>
 			<button class="cancel right-magnet" navigation-trigger="cancelEventEdit()"><i18n>cancel</i18n></button>
 		</div>
 	</article>

--- a/src/main/resources/public/template/events.html
+++ b/src/main/resources/public/template/events.html
@@ -39,9 +39,9 @@
 		<tbody>
 		<tr ng-repeat="event in events.all | orderBy:sort.predicate:sort.reverse" ng-class="{ checked: event.selected }">
 			<td>
-				<behaviour name="contrib" resource="timeline">
+				<authorize name="contrib" resource="timeline">
 					<input type="checkbox" ng-model="event.selected" />
-				</behaviour>
+				</authorize>
 			</td>
 			<td ng-if="timeline.myRights.contrib" ng-click="editEvent(event, $event)">
 				<a>[[event.headline]]</a>

--- a/src/main/resources/public/ts/controller.ts
+++ b/src/main/resources/public/ts/controller.ts
@@ -45,6 +45,7 @@ export interface TimelineGeneratorControllerScope {
     saveTimelineEdit(): void
     cancelTimelineEdit(): void
     saveEventEdit(): void
+    isEventFormValid(): boolean;
     cancelEventEdit(): void
     editTimeline(): void
     editEvent(eventModel: EventModel, event: Event): void
@@ -281,6 +282,10 @@ export const timelineGeneratorController = ng.controller('TimelineGeneratorContr
         else { // when creating an event
             $scope.addEvent();
         }
+    };
+
+    $scope.isEventFormValid = (): boolean => {
+        return $scope.event && $scope.event.headline != undefined;
     };
 
     $scope.cancelEventEdit = function () {


### PR DESCRIPTION
- Rajout contrainte pas d'enregistrement d'event tant que le titre n'est pas renseigné (Problème page blanche avec aucune possibilité d'intéraction si le titre n'est pas renseigné)
- Deprecated `behaviour` remplacé par `authorized` pour les erreurs javascript dans la console (peut contribuer au problème page blanche)
