### PR TITLE
fix: #WB-2944, clean dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,17 @@
   "main": "gulpfile.js",
   "dependencies": {
     "entcore": "~4.8.0-dev",
-    "@types/core-js": "0.9.42",
-    "awesome-typescript-loader": "3.2.1",
     "axios": "0.16.2",
     "core-js": "2.4.1",
+    "entcore-toolkit": "^1.2.0"
+  },
+  "devDependencies": {
+    "@types/core-js": "0.9.42",
+    "@types/jquery": "^2.0.34",
+    "awesome-typescript-loader": "3.2.1",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",
+    "gulp-replace": "1.1.3",
     "gulp-rev": "^7.1.2",
     "gulp-rev-replace": "^0.4.3",
     "gulp-sourcemaps": "^2.6.0",
@@ -18,12 +23,7 @@
     "typescript": "2.4.1",
     "webpack": "3.1.0",
     "webpack-stream": "3.2.0",
-    "yargs": "^8.0.2",
-    "entcore-toolkit": "^1.2.0"
-  },
-  "devDependencies": {
-    "@types/jquery": "^2.0.34",
-    "gulp-replace": "1.1.3"
+    "yargs": "^8.0.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
[Ticket WB-2944](https://edifice-community.atlassian.net/browse/WB-2944)

Dependabot remonte des alertes sur des dépendences obsolètes, qui sont en réalité des `devDependencies`, c'est à dire des libs utilisées lors de l'étape de construction uniquement. Leur code n'est pas embarqué dans le JS final par le bundler.

Ce fix consiste à remettre au propre les `dependencies` et `devDependencies`